### PR TITLE
Store formula state in URL hash for sharing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,21 +5,42 @@ import ResultsDisplay from './ResultsDisplay';
 import ConstantsDisplay from './ConstantsDisplay';
 import {Calculator, SCIPARSER_CONSTANTS} from './Calculator';
 
-const FORMULA_STORAGE_KEY = 'SciCalcFormula';
-
 class App extends React.Component {
   constructor() {
     super();
+    // If there was a formula in the hash when we were instantiated, use it.
+    // This supports sharing of formula via sharing URL.
+    const formulaFromHash = decodeURIComponent((new URL(document.URL).hash).substring(1));
     this.state = {
-      formula: localStorage.getItem(FORMULA_STORAGE_KEY) || ''
+      formula: formulaFromHash || ''
     };
+
+    this.onHashChange = this.onHashChange.bind(this);
+  }
+
+  componentDidMount() {
+    window.addEventListener('hashchange', this.onHashChange);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('hashchange', this.onHashChange, false);
+  }
+
+  onHashChange() {
+    const changedFormula = decodeURIComponent((new URL(document.URL).hash).substring(1));
+    this.setState({formula: changedFormula })
   }
 
   render() {
     let results = [];
     let constants = SCIPARSER_CONSTANTS;
     if (this.state.formula !== '') {
-      localStorage.setItem(FORMULA_STORAGE_KEY, this.state.formula );
+
+      // Store the formula into the URL hash, so that it can be shared, etc.
+      const url_ob = new URL(document.URL);
+      url_ob.hash = '#' + encodeURIComponent(this.state.formula);
+      document.location.href = url_ob.href;
+
       const calculated = Calculator.calculate(this.state.formula);
       results = calculated[0];
       constants = calculated[1];


### PR DESCRIPTION
Previously, we stored state in browser localstorage, but now we're putting it into the URL hash.  The goal is to make it easier to share formula.  I'm not sure if this is a good idea- the URLs get pretty long and ugly.