### PR TITLE
Better implementation of resize handler

### DIFF
--- a/src/FormulaInput.js
+++ b/src/FormulaInput.js
@@ -7,9 +7,6 @@ class FormulaInput extends React.Component {
     this.state = {
       onChange: props.onChange
     };
-    this.onTextChange = this.onTextChange.bind(this);
-    this.onScrollChange = this.onScrollChange.bind(this);
-    this.onMouseUp = this.onMouseUp.bind(this);
 
     this.resultsRef= React.createRef();
     this.formulaRef= React.createRef();
@@ -23,8 +20,22 @@ class FormulaInput extends React.Component {
     this.resultsRef.current.scrollTop = this.formulaRef.current.scrollTop;
   }
 
-  onMouseUp(event) {
-    this.resultsRef.current.style.height = event.target.clientHeight + 'px';
+  componentDidMount() {
+    // const formulaInput = this;
+    const resultsRef = this.resultsRef;
+    // Observe resize events on the input textarea, and resize the output
+    // textarea to match.
+    // Test env doesn't have a ResizeObserver :(
+    if (typeof(ResizeObserver) !== 'undefined') {
+      const resizeOb = new ResizeObserver(function(entries) {
+        // We're observing one element, but entries is an array- grab the first
+        // item
+        resultsRef.current.style.height = entries[0].contentRect.height + 'px';
+      });
+
+      // start observing for resize of the formula input
+      resizeOb.observe(this.formulaRef.current);
+    }
   }
 
   render() {
@@ -40,7 +51,6 @@ class FormulaInput extends React.Component {
             value={this.props.formula}
             onChange={e => this.onTextChange(e)}
             onScroll={e => this.onScrollChange(e)}
-            onMouseUp={e => this.onMouseUp(e)}
             className="FormulaInput"
             placeholder="Enter formula here, e.g.&#10;mass = 3 kg&#10;velocity = 4 m/s&#10;jouleConv = 1 (kg*(m/s)^2)/joule&#10;energy = 1/2 * mass * velocity^2 / jouleConv"
             rows="10"


### PR DESCRIPTION
Adding a resize listener, instead of reacting to onMouseUp.  This is much smoother.