### PR TITLE
Preserve order of variables

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ class App extends React.Component {
 
   render() {
     let results = [];
-    let variables = new Map();
+    let variables = [];
     if (this.state.formula !== '') {
 
       // Store the formula into the URL hash, so that it can be shared, etc.

--- a/src/Calculator.js
+++ b/src/Calculator.js
@@ -34,7 +34,7 @@ class Calculator {
     // We're setting it on "window" so that the parser
     // code can read it.
     window.SCIPARSER_SYMBOLS_MAP = new Map(SCIPARSER_CONSTANTS);
-    const variables = new Map();
+    const variables = [];
     let result = [];
     const lines = text.split('\n');
     for (let i = 0; i < lines.length; i++) {
@@ -52,10 +52,21 @@ class Calculator {
             parsedLine = SciParse(setterMatch[2]);
             // Copy the value of the line to the global set of symbols,
             // overwriting any existing value.
-            // Also keep a map of ONLY the updated symbols, to display
-            // to users
-            window.SCIPARSER_SYMBOLS_MAP.set(setterMatch[1], parsedLine);
-            variables.set(setterMatch[1], parsedLine);
+            // Also keep an array of ONLY the updated symbols, to display
+            // to users.
+            const variableName = setterMatch[1];
+            window.SCIPARSER_SYMBOLS_MAP.set(variableName, parsedLine);
+            const variable = [variableName, parsedLine];
+            // If we've seen this variable before, replace the value
+            const matchesVariable = (element) => element[0] === variableName;
+            const idx = variables.findIndex(matchesVariable);
+            if (-1 === idx) {
+              // Variable not seen, record it
+              variables.push(variable);
+            } else {
+              // Variable previously seen, replace it
+              variables[idx] = variable;
+            }
           } else {
             parsedLine = SciParse(line);
           }

--- a/src/VariablesDisplay.js
+++ b/src/VariablesDisplay.js
@@ -15,15 +15,15 @@ class VariablesDisplay extends React.Component {
   render() {
     const variables = this.props.variables;
 
-    if (0 === variables.size) {
+    if (0 === variables.length) {
       return (<span />);
     }
 
     const variableDisplays = [];
-    const variableNames = [...variables.keys()].sort();
-    for (let i = 0; i < variableNames.length; i++) {
-      const variableKey = variableNames[i];
-      const variableInfo = variables.get(variableKey);
+    for (let i = 0; i < variables.length; i++) {
+      const variable = variables[i];
+      const variableKey = variable[0];
+      const variableInfo = variable[1];
       const variableValue = variableInfo[0];
       const variableUnits = variableInfo[1];
       variableDisplays.push(<VariableDisplay symbol={variableKey} value={variableValue} units={variableUnits} key={variableKey}/>);


### PR DESCRIPTION
Store variables in an array, instead of a map, to preserve order for display purposes