### PR TITLE
Fix bug when units cancel

### DIFF
--- a/src/Calculator.js
+++ b/src/Calculator.js
@@ -1,13 +1,15 @@
 import { parse as SciParse } from './SciGrammar'
 import TypeSimplifier from './TypeSimplifier'
 
+const UNTYPED = "untyped";
+
 // A global used in SciGrammar.pegjs.  We can't pass in
 // arguments, but we share a global environment.
 // We can also dynamically modify this map, e.g.
 // by adding new constants at runtime.
 const SCIPARSER_CONSTANTS = [
-  ["Pi", [Math.PI, "untyped"], "Pi"],
-  ["E", [Math.E, "untyped"], "Euler's Constant"],
+  ["Pi", [Math.PI, UNTYPED], "Pi"],
+  ["E", [Math.E, UNTYPED], "Euler's Constant"],
   ["c", [2.99792e8, "m/s"], "Speed of Light"],
   ["e", [1.60218e-19, "C"], "Elementary Charge"],
   ["Me", [9.10938e-31, "kg"], "Electron Mass"],
@@ -95,4 +97,4 @@ class Calculator {
 }
 
 export default Calculator
-export {SCIPARSER_CONSTANTS}
+export {SCIPARSER_CONSTANTS, UNTYPED}

--- a/src/Calculator.test.js
+++ b/src/Calculator.test.js
@@ -217,6 +217,10 @@ it('handles division', () => {
       input: '2.2e3 / 500 / 800',
       expectedCalcs: [[2.2e3 / 500 / 800, 'untyped', null]]
     },
+    {
+      input: '60.1 K / 303 K',
+      expectedCalcs: [[60.1 / 303, 'untyped', null]]
+    },
   ]);
 });
 

--- a/src/TypeSimplifier.js
+++ b/src/TypeSimplifier.js
@@ -1,4 +1,5 @@
 import { parse as UnitsParse } from './UnitsGrammar'
+import { UNTYPED } from './Calculator'
 
 class TypeSimplifier {
   static simplify(text) {
@@ -28,6 +29,10 @@ class TypeSimplifier {
       } else {
         destination.push(parsedItem.units + '^' + absoluteExponent);
       }
+    }
+
+    if (0 === numerator.length && 0 === denominator.length) {
+      return UNTYPED;
     }
 
     let retval;

--- a/src/TypeSimplifier.test.js
+++ b/src/TypeSimplifier.test.js
@@ -53,7 +53,7 @@ it('simplifies', () => {
     },
     {
       input: '(km km km km km km)/km^6',
-      expected: ''
+      expected: 'untyped'
     },
     {
       input: '((J⋅s)⋅(m/s))/((eV)⋅(J/eV))',
@@ -74,6 +74,10 @@ it('simplifies', () => {
     {
       input: 'C^2/(J*m)^-2',
       expected: 'C^2⋅J^2⋅m^2'
+    },
+    {
+      input: 'K/K',
+      expected: 'untyped'
     }
   ]);
 });

--- a/src/UnitsGrammar.pegjs
+++ b/src/UnitsGrammar.pegjs
@@ -21,7 +21,12 @@
       const unit = unitsArray[i];
       log("In reduceUnits, unit is ", unit);
       if (combined.has(unit.units)) {
-        combined.set(unit.units, combined.get(unit.units) + unit.exponent);
+        const newExponent = combined.get(unit.units) + unit.exponent;
+        if (0 === newExponent) {
+          combined.delete(unit.units);
+        } else {
+          combined.set(unit.units, newExponent);
+        }
       } else {
         combined.set(unit.units, unit.exponent);
       }

--- a/src/UnitsGrammar.test.js
+++ b/src/UnitsGrammar.test.js
@@ -98,6 +98,14 @@ it('parses units', () => {
     {
       input: '(kg*(m/s)^2)/joule',
       expectedResult: [{units: 'm', exponent: 2}, {units: 'kg', exponent: 1}, {units: 'joule', exponent: -1}, {units: 's', exponent: -2}]
+    },
+    {
+      input: 'm*((kg*s)/(kg*s))',
+      expectedResult: [{units: 'm', exponent: 1}]
+    },
+    {
+      input: 'm/(kg/kg)',
+      expectedResult: [{units: 'm', exponent: 1}]
     }
   ]);
 });


### PR DESCRIPTION
For cases like "km/(s/s)".  Also centralizing definition of "untyped" string somewhat.